### PR TITLE
プロトタイプ詳細機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -16,6 +16,10 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def show
+    @prototype = Prototype.find(params[:id])
+  end
+
   private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,5 +1,5 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.id) %>
   <div class="card__body">
     <%= link_to prototype.title, root_path, class: :card__title%>
     <p class="card__summary">

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,9 +2,9 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.title%>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by#{@prototype.user.name}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
@@ -12,19 +12,19 @@
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag(@prototype.image, class: :card__img ) %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= @prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= @prototype.concept %>
           </p>
         </div>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -6,28 +6,50 @@
       </p>
       <%= link_to "by#{@prototype.user.name}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      <% if user_signed_in? && current_user.id == @prototype.user_id%>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
+      
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
-      <div class="prototype__image">
-        <%= image_tag(@prototype.image, class: :card__img ) %>
-      </div>
-      <div class="prototype__body">
-        <div class="prototype__detail">
-          <p class="detail__title">キャッチコピー</p>
-          <p class="detail__message">
-            <%= @prototype.catch_copy %>
-          </p>
+      
+        <div class="prototype__image">
+           <%= image_tag(@prototype.image, class: :card__img ) %>
         </div>
-        <div class="prototype__detail">
-          <p class="detail__title">コンセプト</p>
-          <p class="detail__message">
-            <%= @prototype.concept %>
-          </p>
+        <div class="prototype__body">
+          <div class="prototype__detail">
+            <p class="detail__title">キャッチコピー</p>
+            <p class="detail__message">
+              <%= @prototype.catch_copy %>
+            </p>
+          </div>
+          <div class="prototype__detail">
+            <p class="detail__title">コンセプト</p>
+            <p class="detail__message">
+              <%= @prototype.concept %>
+            </p>
+          </div>
         </div>
-      </div>
+      <% else %>
+        <div class="prototype__image">
+           <%= image_tag(@prototype.image, class: :card__img ) %>
+        </div>
+        <div class="prototype__body">
+          <div class="prototype__detail">
+            <p class="detail__title">キャッチコピー</p>
+            <p class="detail__message">
+              <%= @prototype.catch_copy %>
+            </p>
+          </div>
+          <div class="prototype__detail">
+            <p class="detail__title">コンセプト</p>
+            <p class="detail__message">
+              <%= @prototype.concept %>
+            </p>
+          </div>
+        </div>
+      <% end %>
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
           <%# <%= form_with model: モデル名,local: true do |f|%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "prototypes#index"
 
-  resources :prototypes, only: [:index, :new, :create]
+  resources :prototypes, only: [:index, :new, :create, :show ]
 
 end


### PR DESCRIPTION
# What
プロトタイプの詳細情報を表示する。

# Why
プロトタイプ詳細表示ページにて、プロトタイプの詳細情報を表示するため。

# Gyazo
・プロトタイプ一覧ページにてプロトタイプ情報をクリックすると、該当するプロトタイプの詳細表示ページへ遷移すること。
・プロトタイプ投稿時に登録した情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト）が表示されること。
・画像が表示されており、画像がリンク切れなどにならないこと。（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）
・プロトタイプ詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。
ログインー　https://gyazo.com/78bdf821c7378c0b22234d800211a2ba
ログアウトー　https://gyazo.com/0b98173ecf16aea99cf536a7aa182af4

・ログイン状態且つ、自身が投稿した場合にのみ、「編集する」「削除する」ボタンが表示されること。
ログインー　https://gyazo.com/78bdf821c7378c0b22234d800211a2ba

・ログイン状態の場合でも、自身が投稿していない場合は、「編集する」「削除する」ボタンが表示されないこと。
https://gyazo.com/dae4c4bc7b7f6bffdaf04bb587ce5faa

・ログアウト状態の場合では、「編集する」「削除する」ボタンが表示されないこと。
ログアウトーhttps://gyazo.com/0b98173ecf16aea99cf536a7aa182af4