### PR TITLE
プロトタイプ情報 削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -33,6 +33,12 @@ class PrototypesController < ApplicationController
     end
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+    redirect_to root_path
+  end
+
   private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -35,8 +35,17 @@ class PrototypesController < ApplicationController
 
   def destroy
     prototype = Prototype.find(params[:id])
-    prototype.destroy
-    redirect_to root_path
+    unless user_signed_in?
+      redirect_to new_user_session_path
+    end
+
+    if current_user.id == prototype.user_id
+      prototype.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path
+    end
+    
   end
 
   private

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -11,7 +11,7 @@
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", "/prototypes/#{@prototype.id}", class: :prototype__btn , data: { turbo_method: :delete } %>
         </div>
-      
+      <% end %>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       
         <div class="prototype__image">
@@ -31,25 +31,7 @@
             </p>
           </div>
         </div>
-      <% else %>
-        <div class="prototype__image">
-           <%= image_tag(@prototype.image, class: :card__img ) %>
-        </div>
-        <div class="prototype__body">
-          <div class="prototype__detail">
-            <p class="detail__title">キャッチコピー</p>
-            <p class="detail__message">
-              <%= @prototype.catch_copy %>
-            </p>
-          </div>
-          <div class="prototype__detail">
-            <p class="detail__title">コンセプト</p>
-            <p class="detail__message">
-              <%= @prototype.concept %>
-            </p>
-          </div>
-        </div>
-      <% end %>
+
       <div class="prototype__comments">
         <%# ログインしているユーザーには以下のコメント投稿フォームを表示する %>
           <%# <%= form_with model: モデル名,local: true do |f|%>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -9,7 +9,7 @@
       <% if user_signed_in? && current_user.id == @prototype.user_id%>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", "/prototypes/#{@prototype.id}", class: :prototype__btn , data: { turbo_method: :delete } %>
         </div>
       
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   root to: "prototypes#index"
 
 
-  resources :prototypes, only: [:index, :new, :create, :edit, :update, :show]
+  resources :prototypes
   resources :users
 
 


### PR DESCRIPTION
# what
プロトタイプの情報を削除する機能を実装

# why
削除できるようにするため。

# GyazoのURL
・ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
https://gyazo.com/a00eafe89ece568cad83e5fd1d8b4475