### PR TITLE
編集機能の編集

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,4 +1,7 @@
 class PrototypesController < ApplicationController
+  before_action :correct_user, only: [:edit, :update]
+  before_action :logged_in_user, only: [:edit, :update]
+
   def index
     @prototypes = Prototype.includes(:user)
   end
@@ -36,5 +39,18 @@ class PrototypesController < ApplicationController
   private
   def prototype_params
     params.require(:prototype).permit(:title, :catch_copy, :concept, :image).merge(user_id: current_user.id)
+  end
+
+  def correct_user
+    @user = User.find(params[:id])
+    unless @user == current_user
+      redirect_to root_path
+    end
+  end
+
+  def logged_in_user
+    unless user_signed_in?
+      redirect_to new_user_session_path
+    end
   end
 end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
       <% if user_signed_in? && current_user.id == @prototype.user_id%>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path(@prototype), class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       


### PR DESCRIPTION
# What
投稿の編集機能実装
# Why
編集できるようにするため
# Gyazo
ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
https://gyazo.com/ca7af7cc3d3b575563bfbe4a0fb54c96

必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/1916ff73b8cc6afbd3956561e7cd1198

入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/bc08fc2bb0758b26e8cc723124b68d20

何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
https://gyazo.com/e74e18db1c644d844f587057c2ae179c

ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/b7b766cf67e564ea979658a0ff586a5b
ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移する動画
https://gyazo.com/3b2fcf260b32a5e2f48f682bb3955889
プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
